### PR TITLE
Support ARM architecture for Ubuntu on Raspberry Pi

### DIFF
--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -2,6 +2,10 @@
 mergerfs_prerequisites:
   - fuse
 mergerfs_dist: "{{ ansible_distribution|lower }}-{{ ansible_distribution_release }}"
-mergerfs_arch: "{{ {'x86_64': 'amd64', 'i386': 'i386'}[ansible_userspace_architecture] }}"
+mergerfs_arch_map:
+  x86_64: amd64
+  i386: i386
+  aarch64: arm64
+mergerfs_arch: "{{ mergerfs_arch_map[ansible_userspace_architecture | default(ansible_architecture) ] }}"
 mergerfs_pkg_prefix: "mergerfs_"
 mergerfs_pkg_suffix: ".{{ mergerfs_dist }}_{{ mergerfs_arch }}.deb"

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -6,6 +6,7 @@ mergerfs_arch_map:
   x86_64: amd64
   i386: i386
   aarch64: arm64
+  armv7l: armhf
 mergerfs_arch: "{{ mergerfs_arch_map[ansible_userspace_architecture | default(ansible_architecture) ] }}"
 mergerfs_pkg_prefix: "mergerfs_"
 mergerfs_pkg_suffix: ".{{ mergerfs_dist }}_{{ mergerfs_arch }}.deb"


### PR DESCRIPTION
Adds support for pulling ARM builds from https://github.com/trapexit/mergerfs for use on Raspberry Pi. Tested with 64-bit and 32-bit Ubuntu 20.04 LTS (Focal).

`ansible_userspace_architecture` fact is not present on the Pi for some reason, so am falling back to `ansible_architecture`. This appears to give the same result on x64 from a quick test, but I didn't want to change it in case there was a reason it was chosen originally.